### PR TITLE
Adding a timeout parameter to the HTTP request

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,8 @@ template_id = os.environ["TEMPLATE_ID"]
 
 def get_weather():
   url = "http://autodev.openspeech.cn/csp/api/v2.1/weather?openId=aiuicus&clientType=android&sign=android&city=" + city
-  res = requests.get(url).json()
+  # Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+  res = requests.get(url, timeout=0.4).json()
   weather = res['data']['list'][0]
   return weather['weather'], math.floor(weather['temp'])
 


### PR DESCRIPTION
In file: main.py, method: get_weather, a request is made without a timeout parameter. The requests.get method in Python does not use any default timeout value and should be explicitly set. Otherwise, if the recipient server is unavailable to service the request, the application making the request may stall indefinitely.  

What should be the timeout value? A good practice is to set it under 500ms. This PR proposes the value to be 400ms. However, this may vary depending on the use case. More information is available in: https://docs.python-requests.org/en/latest/user/advanced/#timeouts 